### PR TITLE
Add new lib/libelf/ entries in Git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ tags
 /lib/libelf/config.cache
 /lib/libelf/config.h
 /lib/libelf/config.status
+/lib/libelf/config.log
+/lib/libelf/libelf.pc
 /lib/libelf/lib/Makefile
 /lib/libelf/lib/stamp-h
 /lib/libelf/lib/sys_elf.h


### PR DESCRIPTION
A build can currently generate these two files:
  - lib/libelf/config.log
  - lib/libelf/libelf.pc