### PR TITLE
Use integers instead of chars to store -1 values

### DIFF
--- a/src/crypto/bf_util.cc
+++ b/src/crypto/bf_util.cc
@@ -11,7 +11,7 @@
 BF_KEY bf_e_key, bf_d_key;
 
 static const char eggdrop_blowfish_base64[65] = "./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-static const char eggdrop_blowfish_base64_index[256] = {
+static const int eggdrop_blowfish_base64_index[256] = {
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  0,  1,
@@ -107,7 +107,7 @@ bd::String egg_bf_decrypt(bd::String in, const bd::String& key)
 
   BF_set_key(&bf_d_key, key.length(), (unsigned char *)key.data());
   bf_data data;
-  char val;
+  int val;
   size_t part;
   char *s = (char *)in.data();
   for (size_t i = 0; i < in.length(); i += 12) {
@@ -115,11 +115,11 @@ bd::String egg_bf_decrypt(bd::String in, const bd::String& key)
     data.lr.right = 0;
     for (part = 0; part < 6; part++) {
       if ((val = eggdrop_blowfish_base64_index[int(*s++)]) == -1) return out;
-      data.lr.right |= val << part * 6;
+      data.lr.right |= (char)val << part * 6;
     }
     for (part = 0; part < 6; part++) {
       if ((val = eggdrop_blowfish_base64_index[int(*s++)]) == -1) return out;
-      data.lr.left |= val << part * 6;
+      data.lr.left |= (char)val << part * 6;
     }
     BF_decrypt(&data.bf_long, &bf_d_key);
     for (part = 0; part < 4; part++) {


### PR DESCRIPTION
As a char is now considered as a positive value,
switch to an int array when it contains -1.

This change also address the legitimate following compiler issue:

```
crypto/bf_util.cc: In function ‘bd::String egg_bf_decrypt(bd::String, const bd::String&)’:
crypto/bf_util.cc:102:44: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   if (eggdrop_blowfish_base64_index[in[0]] == -1) return out;
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
crypto/bf_util.cc:117:60: warning: comparison is always false due to limited range of data type [-Wtype-limits]
       if ((val = eggdrop_blowfish_base64_index[int(*s++)]) == -1) return out;
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
crypto/bf_util.cc:121:60: warning: comparison is always false due to limited range of data type [-Wtype-limits]
       if ((val = eggdrop_blowfish_base64_index[int(*s++)]) == -1) return out;
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```