### PR TITLE
Fix narrowing compiler issues

### DIFF
--- a/build/autotools/includes/depend.m4
+++ b/build/autotools/includes/depend.m4
@@ -12,7 +12,7 @@ if test $num -ge "3"; then
   CCDEPMODE=gcc3
 #  GCC3="-Wpadded -Wpacked -Wno-unused-parameter -Wmissing-format-attribute -Wdisabled-optimization"
   GCC3_CFLAGS="-W -Wno-unused-parameter -Wdisabled-optimization -Wno-write-strings -Wno-format-security -fno-strict-aliasing -Wno-format-y2k"
-  GCC3_CXXFLAGS="-Woverloaded-virtual"
+  GCC3_CXXFLAGS="-Woverloaded-virtual -Wno-narrowing"
   GCC3DEB="-Wno-disabled-optimization -Wmissing-format-attribute"
 fi
 AC_SUBST(CCDEPMODE)dnl

--- a/configure
+++ b/configure
@@ -4081,7 +4081,7 @@ if test $num -ge "3"; then
   CCDEPMODE=gcc3
 #  GCC3="-Wpadded -Wpacked -Wno-unused-parameter -Wmissing-format-attribute -Wdisabled-optimization"
   GCC3_CFLAGS="-W -Wno-unused-parameter -Wdisabled-optimization -Wno-write-strings -Wno-format-security -fno-strict-aliasing -Wno-format-y2k"
-  GCC3_CXXFLAGS="-Woverloaded-virtual"
+  GCC3_CXXFLAGS="-Woverloaded-virtual -Wno-narrowing"
   GCC3DEB="-Wno-disabled-optimization -Wmissing-format-attribute"
 fi
 


### PR DESCRIPTION
When compiling cmds.So, the compiler can raise the following error:
`../lib/bdlib/src/base64.h:56:1: error: narrowing conversion of ‘-1’ from ‘int’ to ‘char’ inside { } [-Wnarrowing]`

A workaround has been committed upstream, but as cmds code includes
the header, there is a need to apply the same workaround here too.

References:
  - https://github.com/bdrewery/bdlib/issues/4
  - https://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing
  - https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html