### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/bdlib"]
 	path = lib/bdlib
-	url = git://github.com/bdrewery/bdlib.git
+	url = https://github.com/bdrewery/bdlib.git


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported.
https://github.blog/2021-09-01-improving-git-protocol-security-github/