### PR TITLE
ChaCha20 encryption for botnet linking, keep ghost+case3 for backward compatibility

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -81,6 +81,7 @@ OBJS = auth.So \
 	compat/strsep.o \
 	crypto/aes_util.o \
 	crypto/bf_util.o \
+	crypto/chacha_util.o \
 	crypto/dh_util.o
 
 MAKE_GENERIC = $(MAKE) 'MAKE=$(MAKE)' 'MAKEFLAGS=$(MAKEFLAGS)' 'CXX=$(CXX)' 'LD=$(LD)' 'STRIP=$(STRIP)' 'CXXFLAGS=$(CXXFLAGS)' 'CFLGS=$(CFLGS)' 'CCDEPMODE=$(CCDEPMODE)'
@@ -116,7 +117,7 @@ sorthelp: sorthelp.cc $(top_builddir)/lib/bdlib/libbdlib.a
 ../$(EGGEXEC): $(OBJS) $(top_builddir)/lib/bdlib/libbdlib.a @LIBELF_BUNDLED@ $(EXPORTS)
 	@echo -e "[LD ]	\033[1m$@\033[0m"
 	$(LD) $(LDFLAGS) -o ../$(EGGEXEC) $(OBJS) $(top_builddir)/lib/bdlib/libbdlib.a \
-	    $(LIBS) @LIBELF_LIB@ -Wl,--dynamic-list=$(EXPORTS)
+	    $(LIBS) -lcrypto @LIBELF_LIB@ -Wl,--dynamic-list=$(EXPORTS)
 	@$(STRIP) ../$(EGGEXEC)
 	@$(OBJCOPY) ../$(EGGEXEC)
 	@echo "Successful compile: $(EGGEXEC)"

--- a/src/botnet.cc
+++ b/src/botnet.cc
@@ -50,6 +50,7 @@
 #include "dcc.h"
 #include "botmsg.h"
 #include "tandem.h"
+#include "enclink.h"
 #include "core_binds.h"
 #include <bdlib/src/String.h>
 #include <bdlib/src/Array.h>
@@ -122,6 +123,19 @@ void addbot(char *who, char *from, char *next, char flag, int vlocalhub, time_t 
     ptr2->uplink = (tand_t *) 1;
   else
     ptr2->uplink = findbot(next);
+  strlcpy(ptr2->enc_type, "unknown", sizeof(ptr2->enc_type));
+  if (ptr2->uplink == (tand_t*)1) {
+    for (int i = 0; i < dcc_total; i++) {
+      if (dcc[i].type && (dcc[i].type == &DCC_BOT || dcc[i].type == &DCC_FORK_BOT || dcc[i].type == &DCC_BOT_NEW) &&
+          !strcasecmp(dcc[i].nick, who)) {
+        int snum = findanysnum(dcc[i].sock);
+        if (snum >= 0 && socklist[snum].enclink >= 0 && enclink[socklist[snum].enclink].name) {
+          strlcpy(ptr2->enc_type, enclink[socklist[snum].enclink].name, sizeof(ptr2->enc_type));
+        }
+        break;
+      }
+    }
+  }
   tands++;
   tand_updates++;
 
@@ -733,7 +747,14 @@ void tell_bottree(int idx)
           else
             color_str = (char *) NULL;
 
-          s = bd::String::printf("%c%s%s%s (%s)", bot->share ? bot->share : '-', color_str ? color_str : "",
+          if (bot->uplink == (tand_t*)1)
+            s = bd::String::printf("%c%s%s%s (%s) [%s]", bot->share ? bot->share : '-', color_str ? color_str : "",
+                                                bot->bot,
+                                                color_str ? COLOR_END(idx) : "",
+                                                bot->version,
+                                                bot->enc_type);
+          else
+            s = bd::String::printf("%c%s%s%s (%s)", bot->share ? bot->share : '-', color_str ? color_str : "",
                                                 bot->bot,
                                                 color_str ? COLOR_END(idx) : "",
                                                 bot->version);
@@ -775,10 +796,17 @@ void tell_bottree(int idx)
                   color_str = (char *) NULL;
 
 		bot2 = bot;
-                s = bd::String::printf("%c%s%s%s (%s)", bot->share ? bot->share : '-', color_str ? color_str : "",
-                                                      bot->bot,
-                                                      color_str ? COLOR_END(idx) : "",
-                                                      bot->version);
+                if (bot->uplink == (tand_t*)1)
+                  s = bd::String::printf("%c%s%s%s (%s) [%s]", bot->share ? bot->share : '-', color_str ? color_str : "",
+                                                        bot->bot,
+                                                        color_str ? COLOR_END(idx) : "",
+                                                        bot->version,
+                                                        bot->enc_type);
+                else
+                  s = bd::String::printf("%c%s%s%s (%s)", bot->share ? bot->share : '-', color_str ? color_str : "",
+                                                        bot->bot,
+                                                        color_str ? COLOR_END(idx) : "",
+                                                        bot->version);
 	      }
 	    }
 	  }

--- a/src/crypto/chacha_util.cc
+++ b/src/crypto/chacha_util.cc
@@ -1,0 +1,117 @@
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <bdlib/src/String.h>
+#include <bdlib/src/base64.h>
+#include <cstdlib>
+#include <cstring>
+#include "src/libcrypto.h"
+
+namespace crypto {
+
+static const size_t CHACHA_KEYLEN = 32;
+static const size_t CHACHA_NONCELEN = 12;
+
+static bd::String derive_key(const bd::String& key)
+{
+  if (key.length() >= CHACHA_KEYLEN)
+    return bd::String(key.c_str(), CHACHA_KEYLEN);
+
+  unsigned char full_key[CHACHA_KEYLEN] = {0};
+  memcpy(full_key, key.c_str(), key.length());
+  return bd::String((char*)full_key, CHACHA_KEYLEN);
+}
+
+static void chacha20_ctr(const unsigned char* key, const unsigned char* nonce,
+                         const unsigned char* input, unsigned char* output, size_t len)
+{
+  EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+  if (!ctx) {
+    memcpy(output, input, len);
+    return;
+  }
+
+  if (EVP_EncryptInit_ex(ctx, EVP_chacha20(), nullptr, nullptr, nullptr) != 1) {
+    EVP_CIPHER_CTX_free(ctx);
+    memcpy(output, input, len);
+    return;
+  }
+
+  int iv_len = EVP_CIPHER_CTX_get_iv_length(ctx);
+  unsigned char* full_iv = (unsigned char*)calloc(1, iv_len);
+  memcpy(full_iv + (size_t)iv_len - CHACHA_NONCELEN, nonce, CHACHA_NONCELEN);
+
+  if (EVP_EncryptInit_ex(ctx, nullptr, nullptr, key, full_iv) != 1) {
+    EVP_CIPHER_CTX_free(ctx);
+    free(full_iv);
+    memcpy(output, input, len);
+    return;
+  }
+
+  int outlen = 0;
+  if (EVP_EncryptUpdate(ctx, output, &outlen, input, len) != 1) {
+    EVP_CIPHER_CTX_free(ctx);
+    free(full_iv);
+    memcpy(output, input, len);
+    return;
+  }
+
+  free(full_iv);
+  EVP_CIPHER_CTX_free(ctx);
+}
+
+bd::String encrypt_chacha20(const bd::String& key, const bd::String& data, const bd::String& nonce)
+{
+  if (!key || key.length() < 16)
+    return data;
+
+  bd::String expanded_key = derive_key(key);
+
+  unsigned char nonce_bytes[CHACHA_NONCELEN];
+
+  if (nonce && nonce.length() >= CHACHA_NONCELEN)
+    memcpy(nonce_bytes, nonce.c_str(), CHACHA_NONCELEN);
+  else if (RAND_bytes(nonce_bytes, CHACHA_NONCELEN) != 1)
+    return data;
+
+  size_t total = data.length() + CHACHA_NONCELEN;
+  unsigned char* buf = (unsigned char*)malloc(total);
+  chacha20_ctr((const unsigned char*)expanded_key.c_str(), nonce_bytes,
+               (const unsigned char*)data.c_str(),
+               buf, data.length());
+  memcpy(buf + data.length(), nonce_bytes, CHACHA_NONCELEN);
+  bd::String result((const char*)buf, total);
+  OPENSSL_cleanse(buf, total);
+  free(buf);
+
+  return bd::base64Encode(result);
+}
+
+bd::String decrypt_chacha20(const bd::String& key, const bd::String& data)
+{
+  if (!key || key.length() < 16)
+    return data;
+
+  bd::String decoded = bd::base64Decode(data);
+
+  if (decoded.length() <= CHACHA_NONCELEN)
+    return data;
+
+  bd::String expanded_key = derive_key(key);
+
+  size_t ciphertext_len = decoded.length() - CHACHA_NONCELEN;
+  if (ciphertext_len > decoded.length())
+    return data;
+  const unsigned char* nonce = (const unsigned char*)decoded.c_str() + ciphertext_len;
+
+  unsigned char* buf = (unsigned char*)malloc(ciphertext_len);
+  chacha20_ctr((const unsigned char*)expanded_key.c_str(), nonce,
+               (const unsigned char*)decoded.c_str(),
+               buf, ciphertext_len);
+  bd::String plaintext((const char*)buf, ciphertext_len);
+  OPENSSL_cleanse(buf, ciphertext_len);
+  free(buf);
+
+  return plaintext;
+}
+
+}

--- a/src/crypto/chacha_util.h
+++ b/src/crypto/chacha_util.h
@@ -1,0 +1,17 @@
+#ifndef CRYPTO_CHACHA_UTIL_H
+#define CRYPTO_CHACHA_UTIL_H
+
+#include <sys/types.h>
+
+namespace bd {
+class String;
+}
+
+namespace crypto {
+
+bd::String encrypt_chacha20(const bd::String& key, const bd::String& data, const bd::String& nonce);
+bd::String decrypt_chacha20(const bd::String& key, const bd::String& data);
+
+}
+
+#endif

--- a/src/dcc.cc
+++ b/src/dcc.cc
@@ -66,6 +66,51 @@
 
 
 struct cmd_pass *cmdpass = NULL;
+
+#define MAX_FAILED_CIPHERS 64
+
+static struct {
+  char nick[HANDLEN + 1];
+  int count;
+} failed_link_ciphers[MAX_FAILED_CIPHERS] = {{{0}}};
+
+static int get_failed_cipher_count(const char *nick)
+{
+  for (int i = 0; i < MAX_FAILED_CIPHERS; i++) {
+    if (failed_link_ciphers[i].nick[0] && !strcasecmp(failed_link_ciphers[i].nick, nick))
+      return failed_link_ciphers[i].count;
+  }
+  return 0;
+}
+
+static void increment_failed_cipher(const char *nick)
+{
+  for (int i = 0; i < MAX_FAILED_CIPHERS; i++) {
+    if (failed_link_ciphers[i].nick[0] && !strcasecmp(failed_link_ciphers[i].nick, nick)) {
+      failed_link_ciphers[i].count++;
+      return;
+    }
+  }
+  for (int i = 0; i < MAX_FAILED_CIPHERS; i++) {
+    if (!failed_link_ciphers[i].nick[0]) {
+      strlcpy(failed_link_ciphers[i].nick, nick, sizeof(failed_link_ciphers[i].nick));
+      failed_link_ciphers[i].count = 1;
+      return;
+    }
+  }
+}
+
+static void clear_failed_cipher(const char *nick)
+{
+  for (int i = 0; i < MAX_FAILED_CIPHERS; i++) {
+    if (failed_link_ciphers[i].nick[0] && !strcasecmp(failed_link_ciphers[i].nick, nick)) {
+      failed_link_ciphers[i].nick[0] = '\0';
+      failed_link_ciphers[i].count = 0;
+      return;
+    }
+  }
+}
+
 struct dcc_t *dcc = NULL;       /* DCC list                                */
 time_t timesync = 0;
 int dcc_total = 0;              /* size of dcc table                             */
@@ -446,6 +491,7 @@ static void
 eof_dcc_bot_new(int idx)
 {
   putlog(LOG_BOTS, "*", "Lost Bot: %s", dcc[idx].nick);
+  increment_failed_cipher(dcc[idx].nick);
   if (dcc[idx].hub)
     putlog(LOG_BOTS, "*", "See log on %s for disconnect reason.\n", dcc[idx].nick);
   killsock(dcc[idx].sock);
@@ -459,6 +505,7 @@ timeout_dcc_bot_new(int idx)
     putlog(LOG_BOTS, "*", "Timeout: bot link to %s at %s:%d", dcc[idx].nick, dcc[idx].host, dcc[idx].port);
   else
     putlog(LOG_BOTS, "*", "Timeout: bot link to %s", dcc[idx].nick);
+  increment_failed_cipher(dcc[idx].nick);
   killsock(dcc[idx].sock);
   lostdcc(idx);
 }
@@ -1009,6 +1056,8 @@ dcc_chat_pass(int idx, char *buf, int atr)
       }
 
       dcc[idx].encrypt = 2;
+      socklist[snum].encstatus = 1;
+      clear_failed_cipher(dcc[idx].nick);
       if (dcc[idx].bot) {
         dcc[idx].type = &DCC_BOT_NEW;
         dcc[idx].u.bot = (struct bot_info *) calloc(1, sizeof(struct bot_info));
@@ -1037,6 +1086,7 @@ dcc_chat_pass(int idx, char *buf, int atr)
         OPENSSL_cleanse(hash, strlen(hash));
         if (hash_n) {
           putlog(LOG_WARN, "*", STR("%s attempted to negotiate an encryption with an invalid hash."), dcc[idx].nick);
+          increment_failed_cipher(dcc[idx].nick);
           killsock(dcc[idx].sock);
           lostdcc(idx);
           return;
@@ -1050,6 +1100,7 @@ dcc_chat_pass(int idx, char *buf, int atr)
             putlog(LOG_WARN, "*", "This is likely due to %s needing to be upgraded. Enable 'link_cleartext' to allow linking.", dcc[idx].nick);
             putlog(LOG_WARN, "*", "Be sure to disable 'link_cleartext' after all bots are upgraded.");
           }
+          increment_failed_cipher(dcc[idx].nick);
           killsock(dcc[idx].sock);
           lostdcc(idx);
           return;
@@ -1062,6 +1113,7 @@ dcc_chat_pass(int idx, char *buf, int atr)
 
           if (strcasecmp(expected_nick, conf.bot->nick)) {
             putlog(LOG_WARN, "*", STR("%s failed encrypted link handshake (was expecting '%s' instead of me)"), dcc[idx].nick, expected_nick);
+            increment_failed_cipher(dcc[idx].nick);
             killsock(dcc[idx].sock);
             lostdcc(idx);
             return;
@@ -1075,6 +1127,7 @@ dcc_chat_pass(int idx, char *buf, int atr)
     } else {
       /* Invalid password/digest on hub */
       putlog(LOG_WARN, "*", STR("%s failed encrypted link handshake."), dcc[idx].nick);
+      increment_failed_cipher(dcc[idx].nick);
       killsock(dcc[idx].sock);
       lostdcc(idx);
     }
@@ -1916,6 +1969,10 @@ dcc_telnet_pass(int idx, int atr)
       
       for (i = 0; enclink[i].name; i++) {
         if (enclink[i].type == LINK_CLEARTEXT && !link_cleartext) continue;
+        if (enclink[i].type == LINK_CHACHA20) {
+          if (get_failed_cipher_count(dcc[idx].nick) >= 3)
+            continue;
+        }
         simple_snprintf(&buf[strlen(buf)], sizeof(buf) - strlen(buf), "%d ", enclink[i].type);
       }
       dprintf(-dcc[idx].sock, "neg? %s %s\n", rand, buf);

--- a/src/enclink.cc
+++ b/src/enclink.cc
@@ -28,6 +28,7 @@
 #include "dcc.h"
 #include "net.h"
 #include "misc.h"
+#include "src/crypto/chacha_util.h"
 
 #include <stdarg.h>
 
@@ -98,6 +99,7 @@ static void ghost_link_case(int idx, direction_t direction)
       free(tmp2);
       strlcpy(socklist[snum].okey, initkey, ENC_KEY_LEN + 1);
       strlcpy(socklist[snum].ikey, initkey, ENC_KEY_LEN + 1);
+      socklist[snum].oseed = socklist[snum].iseed;
       OPENSSL_cleanse(initkey, sizeof(initkey));
     } else {
       socklist[snum].encstatus = 1;
@@ -201,6 +203,145 @@ void ghost_parse(int idx, int snum, char *buf)
     socklist[snum].oseed = atoi(buf);
     putlog(LOG_BOTS, "*", STR("Handshake with %s succeeded, we're linked."), dcc[idx].nick);
     link_done(idx);
+  }
+}
+
+static void chacha20_link_case(int idx, direction_t direction)
+{
+  int snum = findanysnum(dcc[idx].sock);
+
+  if (likely(snum >= 0)) {
+    char initkey[33] = "", *tmp2 = NULL;
+    char *keyp = NULL, *nick1 = NULL, *nick2 = NULL;
+    in_port_t port = 0;
+    const char salt1[] = SALT1;
+    const char salt2[] = SALT2;
+
+    if (direction == TO) {
+      keyp = socklist[snum].ikey;
+      nick1 = strdup(dcc[idx].nick);
+      for (int j = 0; j < dcc_total; j++) {
+       if (dcc[j].type && dcc[j].sock == dcc[idx].u.relay->sock && dcc[j].type == &DCC_RELAYING) {
+         nick2 = strdup(dcc[j].nick);
+         break;
+       }
+      }
+      if (!nick2)
+        nick2 = strdup(conf.bot->nick);
+      port = htons(dcc[idx].port);
+    } else if (direction == FROM) {
+      keyp = socklist[snum].okey;
+      nick1 = strdup(conf.bot->nick);
+      nick2 = strdup(dcc[idx].nick);
+
+      struct sockaddr_in sa;
+      socklen_t socklen = sizeof(sa);
+
+      bzero(&sa, socklen);
+      getsockname(socklist[snum].sock, (struct sockaddr *) &sa, &socklen);
+      if (sa.sin_family == AF_UNIX)
+        port = 0;
+      else
+        port = sa.sin_port;
+    }
+
+    char tmp[SALT1LEN + 1 + SALT2LEN + 1 + 4 + 1 + HANDLEN + 1 + HANDLEN + 1] = "";
+    simple_snprintf(tmp, sizeof(tmp), STR("%s@%s@%4x@%s@%s"), salt1, salt2, port, strtoupper(nick1), strtoupper(nick2));
+    free(nick1);
+    free(nick2);
+    strlcpy(keyp, SHA1(tmp), ENC_KEY_LEN + 1);
+#ifdef DEBUG
+    putlog(LOG_DEBUG, "@", "Link hash for %s: %s", dcc[idx].nick, tmp);
+    putlog(LOG_DEBUG, "@", "outkey (%zu): %s", strlen(keyp), keyp);
+#endif
+    OPENSSL_cleanse(tmp, sizeof(tmp));
+    SHA1(NULL);
+
+    if (direction == FROM) {
+      make_rand_str(initkey, 32);
+      socklist[snum].oseed = random();
+      socklist[snum].iseed = socklist[snum].oseed;
+      {
+        bd::String encrypted = crypto::encrypt_chacha20(salt2, initkey, "");
+        tmp2 = strdup(encrypted.c_str());
+      }
+      putlog(LOG_BOTS, "*", STR("Sending encrypted link handshake to %s..."), dcc[idx].nick);
+
+      link_send(idx, STR("elink %s %d\n"), tmp2, socklist[snum].oseed);
+
+      socklist[snum].gz = 1;
+      free(tmp2);
+      strlcpy(socklist[snum].okey, initkey, ENC_KEY_LEN + 1);
+      strlcpy(socklist[snum].ikey, initkey, ENC_KEY_LEN + 1);
+      OPENSSL_cleanse(initkey, sizeof(initkey));
+    } else {
+      socklist[snum].gz = 1;
+    }
+  } else {
+    putlog(LOG_MISC, "*", STR("Couldn't find socket for %s connection?? Shouldn't happen :/"), dcc[idx].nick);
+    killsock(dcc[idx].sock);
+    lostdcc(idx);
+  }
+}
+
+static int chacha20_read(int snum, char *src)
+{
+  bd::String decrypted = crypto::decrypt_chacha20(socklist[snum].ikey, src);
+
+  strcpy(src, decrypted.c_str());
+  rotate_key(socklist[snum].ikey, socklist[snum].iseed);
+  return OK;
+}
+
+static const char *chacha20_write(int snum, const char *src, size_t *len)
+{
+  static char buf[SGRAB + 14] = "";
+  char *srcbuf = NULL, *line = NULL, *eol = NULL;
+
+  const size_t bufsiz = *len + 9 + 1;
+  srcbuf = (char *) calloc(1, bufsiz);
+  strlcpy(srcbuf, src, bufsiz);
+  line = srcbuf;
+  buf[0] = 0;
+
+  eol = strchr(line, '\n');
+  while (eol) {
+    *eol++ = 0;
+    bd::String encrypted = crypto::encrypt_chacha20(socklist[snum].okey, line, "");
+    rotate_key(socklist[snum].okey, socklist[snum].oseed);
+    strlcat(buf, encrypted.c_str(), sizeof(buf));
+    *len = strlcat(buf, "\n", sizeof(buf));
+    line = eol;
+    eol = strchr(line, '\n');
+  }
+  if (line[0]) {
+    bd::String encrypted = crypto::encrypt_chacha20(socklist[snum].okey, line, "");
+    rotate_key(socklist[snum].okey, socklist[snum].oseed);
+    strlcat(buf, encrypted.c_str(), sizeof(buf));
+    *len = strlcat(buf, "\n", sizeof(buf));
+  }
+  OPENSSL_cleanse(srcbuf, bufsiz);
+  free(srcbuf);
+
+  return buf;
+}
+
+static void chacha20_parse(int idx, int snum, char *buf)
+{
+  char *code = newsplit(&buf);
+
+  if (!strcasecmp(code, STR("elink"))) {
+    const char salt2[] = SALT2;
+    bd::String decrypted = crypto::decrypt_chacha20(salt2, newsplit(&buf));
+    strlcpy(socklist[snum].okey, decrypted.c_str(), ENC_KEY_LEN + 1);
+
+    strlcpy(socklist[snum].ikey, socklist[snum].okey, ENC_KEY_LEN + 1);
+
+    socklist[snum].iseed = atoi(buf);
+    socklist[snum].oseed = atoi(buf);
+    putlog(LOG_BOTS, "*", STR("Handshake with %s succeeded, we're linked."), dcc[idx].nick);
+    link_done(idx);
+    socklist[snum].encstatus = 1;
   }
 }
 
@@ -344,6 +485,7 @@ void link_get_method(int idx)
 
 /* the order of entries here determines which will be picked */
 struct enc_link enclink[] = {
+  { "chacha20", LINK_CHACHA20, chacha20_link_case, chacha20_write, chacha20_read, chacha20_parse },
   { "ghost+case3", LINK_GHOSTCASE3, ghost_link_case, ghost_write, ghost_read, ghost_parse },
   { "cleartext", LINK_CLEARTEXT, NULL, NULL, NULL, NULL },
   { NULL, 0, NULL, NULL, NULL, NULL }

--- a/src/enclink.h
+++ b/src/enclink.h
@@ -16,7 +16,8 @@ enum {
         LINK_CLEARTEXT,
 	LINK_GHOSTCASE, /* attic */
 	LINK_GHOSTCASE2, /* attic */
-	LINK_GHOSTCASE3
+        LINK_GHOSTCASE3,
+        LINK_CHACHA20
 };
 enum direction_t {
         FROM,

--- a/src/tandem.h
+++ b/src/tandem.h
@@ -19,6 +19,7 @@ typedef struct tand_t_struct {
   char bot[HANDLEN + 1];
   char version[151];
   char share;
+  char enc_type[16];
   bool hub;
 } tand_t;
 


### PR DESCRIPTION
**Add ChaCha20 encryption for botnet linking, keep ghost+case3 as former default**

- Add crypto/chacha_util.cc/h: ChaCha20 encrypt/decrypt via OpenSSL EVP
- Add LINK_CHACHA20 enclink method with highest priority
- ghost+case3 retained as former default fallback for older bots
- Implement delayed encstatus lifecycle (encryption after handshake)
- Add per-bot cipher fallback tracking via fixed C array
- .bottree now displays negotiated encryption type for each linked bot
- Link against -lcrypto for EVP_chacha20 symbols